### PR TITLE
Resucitando checkout / carts en Magento cuando se cancela o rechaza el pago

### DIFF
--- a/extension/app/code/community/Aplazame/Aplazame/Block/Checkout/Onepage/Billing.php
+++ b/extension/app/code/community/Aplazame/Aplazame/Block/Checkout/Onepage/Billing.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Extendemos / Rewrite del bloque estandar de Magento
+ * para asegurarnos que el formulario del checkout puebla
+ * la dirección, aunque el usuario no este logineado,
+ * con la dirección del quote.
+ *
+ * Class Aplazame_Aplazame_Block_Checkout_Onepage_Billing
+ */
+class Aplazame_Aplazame_Block_Checkout_Onepage_Billing extends Mage_Checkout_Block_Onepage_Billing
+{
+    /**
+     * Return Sales Quote Address model
+     *
+     * @return Mage_Sales_Model_Quote_Address
+     */
+    public function getAddress()
+    {
+        if (is_null($this->_address)) {
+            $this->_address = $this->getQuote()->getBillingAddress();
+        }
+
+        return $this->_address;
+    }
+}

--- a/extension/app/code/community/Aplazame/Aplazame/Block/Checkout/Onepage/Shipping.php
+++ b/extension/app/code/community/Aplazame/Aplazame/Block/Checkout/Onepage/Shipping.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Extendemos / Rewrite del bloque estandar de Magento
+ * para asegurarnos que el formulario del checkout puebla
+ * la dirección, aunque el usuario no este logineado,
+ * con la dirección del quote.
+ *
+ * Class Aplazame_Aplazame_Block_Checkout_Onepage_Shipping
+ */
+class Aplazame_Aplazame_Block_Checkout_Onepage_Shipping extends Mage_Checkout_Block_Onepage_Shipping
+{
+    /**
+     * Return Sales Quote Address model
+     *
+     * @return Mage_Sales_Model_Quote_Address
+     */
+    public function getAddress()
+    {
+        if (is_null($this->_address)) {
+            $this->_address = $this->getQuote()->getShippingAddress();
+        }
+
+        return $this->_address;
+    }
+}

--- a/extension/app/code/community/Aplazame/Aplazame/Helper/Cart.php
+++ b/extension/app/code/community/Aplazame/Aplazame/Helper/Cart.php
@@ -1,0 +1,108 @@
+<?php
+
+class Aplazame_Aplazame_Helper_Cart extends Mage_Core_Helper_Abstract
+{
+    /**
+     * Funcion que resucita un carrito (quote) en caso
+     * de producirse algún fallo en el proceso de cobro de aplazame
+     * o bien se ha rechazado la operación.
+     */
+    public function resuscitateCartFromOrder(Mage_Sales_Model_Order $order)
+    {
+        $this
+            ->_cancelOrder($order)
+            ->_resuscitateCartItems($order)
+            ->_setCheckoutInfoFromOldOrder($order);
+
+        return $this;
+    }
+
+    /**
+     * Cancela la order anterior que se le pasa como parametro
+     *
+     * @param Mage_Sales_Model_Order $order
+     * @return $this
+     */
+    protected function _cancelOrder(Mage_Sales_Model_Order $order)
+    {
+        $order
+            ->cancel()
+            ->save();
+
+        return $this;
+    }
+
+
+    /**
+     * Re-añade los productos comprados a carrito nuevamente
+     *
+     * @param Mage_Sales_Model_Order $order
+     * @return $this
+     */
+    protected function _resuscitateCartItems(Mage_Sales_Model_Order $order)
+    {
+        foreach($order->getItemsCollection() as $orderItem)
+        {
+            $this->getCart()->addOrderItem($orderItem);
+        }
+
+        $this->getCart()->save();
+
+        return $this;
+    }
+
+    /**
+     * Coge las billing y shipping address de la ultima order
+     * el checkout method y shipping method
+     * y las vuelve a meter en quote actual para que el checkout
+     * pueda tener las direcciones pre-populadas.
+     *
+     * @param Mage_Sales_Model_Order $order
+     */
+    protected function _setCheckoutInfoFromOldOrder(Mage_Sales_Model_Order $order)
+    {
+        $checkoutSession = $this->getCheckoutSession();
+        $quote = $checkoutSession->getQuote();
+        $oldQuote = Mage::getModel('sales/quote')->load($order->getQuoteId());
+
+        $quote->setCheckoutMethod($oldQuote->getCheckoutMethod());
+
+        if($oldQuote->getId())
+        {
+            $billingAddress = clone $oldQuote->getBillingAddress();
+            $billingAddress->setQuote($quote);
+
+            $shippingAddress = clone $oldQuote->getShippingAddress();
+            $shippingAddress->setQuote($quote);
+
+            $quote->removeAddress($quote->getBillingAddress()->getId());
+            $quote->removeAddress($quote->getShippingAddress()->getId());
+
+            $quote->setBillingAddress($billingAddress);
+            $quote->setShippingAddress($shippingAddress);
+        }
+
+        $quote->save();
+
+        return $this;
+    }
+
+    /**
+     * @return Mage_Checkout_Model_Cart
+     */
+    public function getCart()
+    {
+        return Mage::getSingleton('checkout/cart');
+    }
+
+    /**
+     * @return Mage_Checkout_Model_Session
+     */
+    public function getCheckoutSession()
+    {
+        return Mage::getSingleton('checkout/session');
+    }
+
+
+
+}

--- a/extension/app/code/community/Aplazame/Aplazame/Model/Api/Serializers.php
+++ b/extension/app/code/community/Aplazame/Aplazame/Model/Api/Serializers.php
@@ -195,7 +195,8 @@ class Aplazame_Aplazame_Model_Api_Serializers extends Varien_Object
         $merchant = array(
             "public_api_key"=>Mage::getStoreConfig('payment/aplazame/public_api_key'),
             "confirmation_url"=>Mage::getUrl("aplazame/payment/confirm"),
-            "cancel_url"=>Mage::getUrl('checkout/onepage'),
+            //"cancel_url"=>Mage::getUrl('checkout/onepage'),
+            "cancel_url"=>Mage::getUrl('aplazame/payment/cancel'),
             "checkout_url"=>Mage::helper('checkout/url')->getCheckoutUrl(),
             "success_url"=>Mage::getUrl('checkout/onepage/success'));
 

--- a/extension/app/code/community/Aplazame/Aplazame/Model/Api/Serializers.php
+++ b/extension/app/code/community/Aplazame/Aplazame/Model/Api/Serializers.php
@@ -195,7 +195,6 @@ class Aplazame_Aplazame_Model_Api_Serializers extends Varien_Object
         $merchant = array(
             "public_api_key"=>Mage::getStoreConfig('payment/aplazame/public_api_key'),
             "confirmation_url"=>Mage::getUrl("aplazame/payment/confirm"),
-            //"cancel_url"=>Mage::getUrl('checkout/onepage'),
             "cancel_url"=>Mage::getUrl('aplazame/payment/cancel'),
             "checkout_url"=>Mage::helper('checkout/url')->getCheckoutUrl(),
             "success_url"=>Mage::getUrl('checkout/onepage/success'));

--- a/extension/app/code/community/Aplazame/Aplazame/controllers/PaymentController.php
+++ b/extension/app/code/community/Aplazame/Aplazame/controllers/PaymentController.php
@@ -67,6 +67,19 @@ class Aplazame_Aplazame_PaymentController extends Mage_Core_Controller_Front_Act
         // $this->_redirect('checkout/onepage');
     }
 
+    public function cancelAction()
+    {
+        $session = $this->_getCheckoutSession();
+        $order = $session->getLastRealOrder();
+
+        if ($order->getId()) {
+
+            Mage::helper('aplazame/cart')->resuscitateCartFromOrder($order);
+        }
+
+        $this->_redirect('checkout/onepage');
+    }
+
     public function historyAction()
     {
         $checkout_token = $this->getRequest()->getParam("checkout_token");

--- a/extension/app/code/community/Aplazame/Aplazame/controllers/PaymentController.php
+++ b/extension/app/code/community/Aplazame/Aplazame/controllers/PaymentController.php
@@ -70,11 +70,14 @@ class Aplazame_Aplazame_PaymentController extends Mage_Core_Controller_Front_Act
     public function cancelAction()
     {
         $session = $this->_getCheckoutSession();
-        $order = $session->getLastRealOrder();
+        $orderId = $session->getLastRealOrderId();
 
-        if ($order->getId()) {
-
-            Mage::helper('aplazame/cart')->resuscitateCartFromOrder($order);
+        if($orderId)
+        {
+            $order = Mage::getModel('sales/order')->loadByIncrementId($orderId);
+            if ($order->getId()) {
+                Mage::helper('aplazame/cart')->resuscitateCartFromOrder($order);
+            }
         }
 
         $this->_redirect('checkout/onepage');

--- a/extension/app/code/community/Aplazame/Aplazame/etc/config.xml
+++ b/extension/app/code/community/Aplazame/Aplazame/etc/config.xml
@@ -15,6 +15,12 @@
             <aplazame>
                 <class>Aplazame_Aplazame_Block</class>
             </aplazame>
+            <checkout>
+                <rewrite>
+                    <onepage_billing>Aplazame_Aplazame_Block_Checkout_Onepage_Billing</onepage_billing>
+                    <onepage_shipping>Aplazame_Aplazame_Block_Checkout_Onepage_Shipping</onepage_shipping>
+                </rewrite>
+            </checkout>
         </blocks>
         <helpers>
             <aplazame>
@@ -22,7 +28,6 @@
             </aplazame>
         </helpers>
     </global>
-
     <adminhtml>
         <events>
             <sales_order_place_after>

--- a/extension/app/design/frontend/base/default/template/aplazame/payment/rdw.phtml
+++ b/extension/app/design/frontend/base/default/template/aplazame/payment/rdw.phtml
@@ -1,4 +1,4 @@
-<?php if (!Mage::helper('core/cookie')->isUserNotAllowSaveCookie()): ?>
+<?php if ((!mageFindClassFile('Mage_Core_Helper_Cookie')) || (!Mage::helper('core/cookie')->isUserNotAllowSaveCookie())): ?>
 
 <script type="text/javascript">
 


### PR DESCRIPTION
El módulo ahora se comporta de esta manera:

1.- Si se rechaza o se cancela el proceso de cobro en Aplazame, RESUCITAMOS el carrito:
- añadiendo los productos que previamente se habían comprado
- Populamos los formularios de direcciones "billing" y "shipping" con los datos que el usuario hubiera introducido en su anterior order
- Cancelamos la order anterior que no se pudo cobrar, para liberar stock, y que la order no se quede en pendiente eternamente ni sea necesaria intervención manual.

Para conseguir esta funcionalidad se han seguido buenas praxis de Magento, tratando de utilizar el patrón de diseño "Observer" que es el idóneo para extender Magento, aunque una de las funcionalidades no podemos conseguirla utilizando observers. Concretamente la funcionalidad de recuperar las billing y shipping address desde la order anterior no es posible utilizando Observers, ya que hay una propiedad declarada como "protected" en el core de Magento, y que además no tiene ningún setter ni getter definido, y que es necesario cambiar para que la funcionalidad se produzca.

Por lo anterior, recomiendo que se publique en la documentación del módulo que "extendemos" o hacemos "rewrite" de dos bloques del core de Magento, que son los siguientes:

Mage_Checkout_Block_Onepage_Billing
Mage_Checkout_Block_Onepage_Shipping

Y que en caso de instalarse en un Magento donde otro módulo también sobreescriba esas dos clases, habría que conciliar los posibles conflictos. 
