### PR TITLE
Fr#widget fixes

### DIFF
--- a/extension/app/code/community/Aplazame/Aplazame/Block/Checkout/Cart/Widget.php
+++ b/extension/app/code/community/Aplazame/Aplazame/Block/Checkout/Cart/Widget.php
@@ -38,6 +38,19 @@ class Aplazame_Aplazame_Block_Checkout_Cart_Widget Extends Mage_Core_Block_Templ
         return Aplazame_Util::formatDecimals(0);
     }
 
+    /**
+     * Solo renderizamos si el modulo esta activo en la tienda actual
+     *
+     * @return string
+     */
+    public function _toHtml()
+    {
+        if(Mage::helper('aplazame')->isEnabled())
+        {
+            return parent::_toHtml();
+        }
 
+        return '';
+    }
 
 }

--- a/extension/app/code/community/Aplazame/Aplazame/Block/Product/Widget.php
+++ b/extension/app/code/community/Aplazame/Aplazame/Block/Product/Widget.php
@@ -40,13 +40,14 @@ class Aplazame_Aplazame_Block_Product_Widget Extends Mage_Core_Block_Template
 
     /**
      * Solo renderizamos si tenemos producto,
+     * y si el modulo esta activo en la tienda actual
      * si no hay producto no renderizamos nada (empty string).
      *
      * @return string
      */
     public function _toHtml()
     {
-        if($this->getProduct() instanceof Mage_Catalog_Model_Product)
+        if(Mage::helper('aplazame')->isEnabled() && $this->getProduct() instanceof Mage_Catalog_Model_Product)
         {
             return parent::_toHtml();
         }

--- a/extension/app/code/community/Aplazame/Aplazame/Block/Product/Widget.php
+++ b/extension/app/code/community/Aplazame/Aplazame/Block/Product/Widget.php
@@ -51,6 +51,6 @@ class Aplazame_Aplazame_Block_Product_Widget Extends Mage_Core_Block_Template
             return parent::_toHtml();
         }
 
-        return 'No Product';
+        return '';
     }
 }

--- a/extension/app/code/community/Aplazame/Aplazame/Helper/Data.php
+++ b/extension/app/code/community/Aplazame/Aplazame/Helper/Data.php
@@ -2,4 +2,8 @@
 
 class Aplazame_Aplazame_Helper_Data extends Mage_Core_Helper_Abstract
 {
+    public function isEnabled()
+    {
+        return (bool) Mage::getStoreConfig('payment/aplazame/active');
+    }
 }


### PR DESCRIPTION
Tenemos un texto "No Product" en el widget product que se renderiza en algunas circunstancias y no debiera.
En instalaciones con varios websites y store views mostramos el widget en todas las store views, incluso aquellas donde el método de pago no esta activo.
Esta rama incluye dos commits arreglando estos dos problemas.
